### PR TITLE
removing intercept callbacks

### DIFF
--- a/g_python/gextension.py
+++ b/g_python/gextension.py
@@ -413,6 +413,20 @@ class Extension:
             self.__intercept_listeners[direction][id] = []
         self.__intercept_listeners[direction][id].append(callback)
 
+    def remove_intercept(self, id=-1):
+        """
+        Clear intercepts per id or all of them when none is given
+        """
+
+        if id == -1:
+            for direction in self.__intercept_listeners:
+                for identifier in self.__intercept_listeners[direction]:
+                    del self.__intercept_listeners[direction][identifier]
+        else:
+            for direction in self.__intercept_listeners:
+                if id in self.__intercept_listeners[direction]:
+                    del self.__intercept_listeners[direction][id]        
+
     def start(self):
         """
         Tries to set up a connection with G-Earth


### PR DESCRIPTION
it improves performance and time on writing extensions, whereas if you've a lot of callbacks, it needs several if's statements to making them works simultaneously